### PR TITLE
Introduced Advection Callback and Compact Model Data Source Updates

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ViennaPSExamples)
 
 include("${CMAKE_SOURCE_DIR}/cmake/prepare.cmake")
 
-find_package(ViennaPS CONFIG PATHS ${ViennaPS_BINARY_DIR})
+find_package(ViennaPS CONFIG PATHS ${ViennaPS_BINARY_DIR} NO_DEFAULT_PATH)
 if(NOT ViennaPS_FOUND)
   message(
     FATAL_ERROR

--- a/Examples/InterpolationDemo/InterpolationDemo.cpp
+++ b/Examples/InterpolationDemo/InterpolationDemo.cpp
@@ -61,7 +61,9 @@ int main(int argc, char *argv[]) {
 
     psRectilinearGridInterpolation<NumericType, InputDim, TargetDim>
         interpolation;
-    interpolation.setDataSource(dataSource);
+
+    auto data = dataSource->get();
+    interpolation.setData(psSmartPointer<decltype(data)>::New(data));
 
     if (interpolation.initialize() && writer.initialize())
       for (int i = 0; i < numSamples; ++i)
@@ -94,7 +96,9 @@ int main(int argc, char *argv[]) {
 
     psNearestNeighborsInterpolation<NumericType, InputDim, TargetDim>
         interpolation(numberOfNeighbors, distanceExponent);
-    interpolation.setDataSource(dataSource);
+
+    auto data = dataSource->get();
+    interpolation.setData(psSmartPointer<decltype(data)>::New(data));
 
     psCSVWriter<NumericType, 4> writer(
         "nn_std_output.csv",
@@ -131,7 +135,8 @@ int main(int argc, char *argv[]) {
         psMedianDistanceScaler<NumericType, InputDim, DataDim>>
         interpolation(numberOfNeighbors, distanceExponent);
 
-    interpolation.setDataSource(dataSource);
+    auto data = dataSource->get();
+    interpolation.setData(psSmartPointer<decltype(data)>::New(data));
 
     psCSVWriter<NumericType, 4> writer(
         "nn_median_output.csv",

--- a/app/README.md
+++ b/app/README.md
@@ -106,12 +106,21 @@ All parameters which are parsed additional to a command are described below. For
 </dl>
 
 ---
-**PROCESS GeometricUniformDeposition**
+**PROCESS SphereDistribution**
 <dl>
-  <dt>time</dt>
-  <dd>process time (numeric value, default: 1)</dd>
-  <dt>rate</dt>
-  <dd>deposition rate (numeric value, default: 1)</dd>
+  <dt>radius</dt>
+  <dd>radius used for sphere distribution (numeric value, default: 1, can be negative for etching)</dd>
+</dl>
+
+---
+**PROCESS BoxDistribution**
+<dl>
+  <dt>halfAxisX</dt>
+  <dd>half the width of the box in x-direction (numeric value, default: 1, can be negative for etching)</dd>
+  <dt>halfAxisY</dt>
+  <dd>half the width of the box in y-direction (numeric value, default: 1, can be negative for etching)</dd>
+  <dt>halfAxisZ</dt>
+  <dd>half the width of the box in z-direction (numeric value, default: 1, can be negative for etching)</dd>
 </dl>
 
 ---

--- a/include/Compact/psCSVReader.hpp
+++ b/include/Compact/psCSVReader.hpp
@@ -67,7 +67,7 @@ public:
     return {header};
   }
 
-  psSmartPointer<std::vector<std::array<NumericType, NumCols>>> apply() {
+  psSmartPointer<std::vector<std::array<NumericType, NumCols>>> readContent() {
     std::ifstream file(filename);
     if (file.is_open()) {
       auto data =

--- a/include/Compact/psCSVWriter.hpp
+++ b/include/Compact/psCSVWriter.hpp
@@ -61,45 +61,47 @@ public:
 
   void setHeader(std::string passedHeader) { header = passedHeader; }
 
-  void writeRow(const std::array<NumericType, NumCols> &data) {
+  bool writeRow(const std::array<NumericType, NumCols> &data) {
     if (!initialized)
       if (!initialize())
-        return;
+        return false;
 
-    if (file.is_open())
-      file << join(data.cbegin(), data.cend()) << '\n';
+    file << join(data.cbegin(), data.cend()) << '\n';
+    return true;
   }
 
-  void writeRow(const std::vector<NumericType> &data) {
+  bool writeRow(const std::vector<NumericType> &data) {
     if (!initialized)
       if (!initialize())
-        return;
+        return false;
 
     if (data.size() != NumCols) {
       std::cout << "Unexpected number of items in the provided row!\n";
-      return;
+      return false;
     }
     if (!file.is_open()) {
       std::cout << "Couldn't open file `" << filename << "`\n";
-      return;
+      return false;
     }
     file << join(data.cbegin(), data.cend()) << '\n';
+    return true;
   }
 
-  void writeRow(std::initializer_list<NumericType> data) {
+  bool writeRow(std::initializer_list<NumericType> data) {
     if (!initialized)
       if (!initialize())
-        return;
+        return false;
 
     if (data.size() != NumCols) {
       std::cout << "Unexpected number of items in the provided row!\n";
-      return;
+      return false;
     }
     if (!file.is_open()) {
       std::cout << "Couldn't open file `" << filename << "`\n";
-      return;
+      return false;
     }
     file << join(data.begin(), data.end()) << '\n';
+    return true;
   }
 
   void flush() {

--- a/include/Compact/psDataSource.hpp
+++ b/include/Compact/psDataSource.hpp
@@ -9,16 +9,64 @@
 #include <psSmartPointer.hpp>
 
 template <typename NumericType, int D> class psDataSource {
-
 public:
-  using DataPtr = psSmartPointer<std::vector<std::array<NumericType, D>>>;
-  virtual DataPtr getAll() = 0;
+  using DataItemType = std::array<NumericType, D>;
+  using DataVectorType = std::vector<DataItemType>;
 
+  // Returns a smart pointer to the in-memory copy of the data. If the in-memory
+  // copy of the data is empty, the read function is called on the data source.
+  const DataVectorType &get() {
+    if (data.empty()) {
+      auto d = read();
+      if (d)
+        data = *d;
+    }
+    return data;
+  };
+
+  // Synchronizes the in-memory copy of the data with the underlying data source
+  // (e.g. CSV file)
+  bool sync() {
+    if (modified) {
+      if (!write(psSmartPointer<DataVectorType>::New(data)))
+        return false;
+    }
+    modified = false;
+    return true;
+  };
+
+  // Adds an item to the in-memory copy of the data
+  void add(const DataItemType &item) {
+    modified = true;
+    data.push_back(item);
+  }
+
+  // Optional: the data source can also expose additional parameters that are
+  // stored alongside the actual data (e.g. depth at which trench diameters were
+  // captured)
   virtual std::vector<NumericType> getPositionalParameters() { return {}; }
 
+  // These optional parameters can also be named
   virtual std::unordered_map<std::string, NumericType> getNamedParameters() {
     return {};
   }
+
+private:
+  // An in-memory copy of the data
+  DataVectorType data;
+
+  // Flag that specifies whether the in-memory copy of the data has been
+  // modified (i.e. whether the append function has been called)
+  bool modified = false;
+
+  // Each implementing class has to implement the read function, which reads the
+  // complete data of the underlying datasource (e.g. CSV file)
+  virtual psSmartPointer<DataVectorType> read() = 0;
+
+  // Each implementing class has to implement the write function, which writes
+  // the content of the in-memory data into the underlying datasource (e.g. CSV
+  // file)
+  virtual bool write(psSmartPointer<DataVectorType>) = 0;
 };
 
 #endif

--- a/include/Compact/psNearestNeighborsInterpolation.hpp
+++ b/include/Compact/psNearestNeighborsInterpolation.hpp
@@ -39,8 +39,8 @@ class psNearestNeighborsInterpolation
   using Parent::DataDim;
   using Parent::dataSource;
 
-  using DataPtr = typename decltype(dataSource)::element_type::DataPtr;
   using DataVector = std::vector<std::array<NumericType, DataDim>>;
+  using DataPtr = psSmartPointer<DataVector>;
 
   int numberOfNeighbors;
   PointLocator locator;
@@ -70,9 +70,10 @@ public:
     if (!dataSource)
       return false;
 
-    data = dataSource->getAll();
-    if (!data)
-      return false;
+    // Get a copy of the data from the dataSource
+    // This is required since we are modifying the data in-place (the locator
+    // sorts the points).
+    data = psSmartPointer<DataVector>::New(dataSource->get());
 
     if (data->size() == 0)
       return false;

--- a/include/Compact/psRectilinearGridInterpolation.hpp
+++ b/include/Compact/psRectilinearGridInterpolation.hpp
@@ -15,19 +15,15 @@ class psRectilinearGridInterpolation
 
   using Parent = psValueEstimator<NumericType, InputDim, OutputDim, bool>;
 
+  using typename Parent::DataVector;
   using typename Parent::InputType;
   using typename Parent::OutputType;
 
+  using Parent::data;
+  using Parent::dataChanged;
   using Parent::DataDim;
-  using Parent::dataSource;
-
-  using DataVector = std::vector<std::array<NumericType, DataDim>>;
-  using DataPtr = psSmartPointer<DataVector>;
-
-  DataPtr data = nullptr;
 
   std::array<std::set<NumericType>, InputDim> uniqueValues;
-  bool initialized = false;
 
   // For rectilinear grid interpolation to work, we first have to ensure that
   // our input coordinates are arranged in a certain way
@@ -89,12 +85,10 @@ public:
   psRectilinearGridInterpolation() {}
 
   bool initialize() override {
-    if (!dataSource)
+    if (!data) {
+      std::cout << "No data provided to psRectilinearGridInterpolation!\n";
       return false;
-
-    // Get a copy of the data from the dataSource
-    // This is required since we are modifying the data in-place.
-    data = psSmartPointer<DataVector>::New(dataSource->get());
+    }
 
     if (data->size() == 0)
       return false;
@@ -122,12 +116,12 @@ public:
         return false;
       }
 
-    initialized = true;
+    dataChanged = false;
     return true;
   }
 
   std::tuple<OutputType, bool> estimate(const InputType &input) override {
-    if (!initialized)
+    if (dataChanged)
       if (!initialize())
         return {{}, {}};
 

--- a/include/Compact/psRectilinearGridInterpolation.hpp
+++ b/include/Compact/psRectilinearGridInterpolation.hpp
@@ -21,8 +21,8 @@ class psRectilinearGridInterpolation
   using Parent::DataDim;
   using Parent::dataSource;
 
-  using DataPtr = typename decltype(dataSource)::element_type::DataPtr;
   using DataVector = std::vector<std::array<NumericType, DataDim>>;
+  using DataPtr = psSmartPointer<DataVector>;
 
   DataPtr data = nullptr;
 
@@ -92,8 +92,11 @@ public:
     if (!dataSource)
       return false;
 
-    data = dataSource->getAll();
-    if (!data)
+    // Get a copy of the data from the dataSource
+    // This is required since we are modifying the data in-place.
+    data = psSmartPointer<DataVector>::New(dataSource->get());
+
+    if (data->size() == 0)
       return false;
 
     auto equalSize = rearrange(data->begin(), data->end(), 0, true);

--- a/include/Compact/psValueEstimator.hpp
+++ b/include/Compact/psValueEstimator.hpp
@@ -16,13 +16,17 @@ public:
 
   static constexpr int DataDim = InputDim + OutputDim;
 
+  using DataVector = std::vector<std::array<NumericType, DataDim>>;
+  using DataPtr = psSmartPointer<DataVector>;
+
 protected:
-  psSmartPointer<psDataSource<NumericType, DataDim>> dataSource = nullptr;
+  DataPtr data = nullptr;
+  bool dataChanged = true;
 
 public:
-  void setDataSource(
-      psSmartPointer<psDataSource<NumericType, DataDim>> passedDataSource) {
-    dataSource = passedDataSource;
+  void setData(DataPtr passedData) {
+    data = passedData;
+    dataChanged = true;
   }
 
   virtual bool initialize() { return true; }

--- a/include/Models/PlasmaDamage.hpp
+++ b/include/Models/PlasmaDamage.hpp
@@ -181,10 +181,10 @@ private:
 };
 
 template <typename NumericType, int D>
-class DamageModel : public psVolumeModel<NumericType, D> {
+class DamageModel : public psAdvectionCalback<NumericType, D> {
 protected:
-  using psVolumeModel<NumericType, D>::domain;
-  using psVolumeModel<NumericType, D>::tracer;
+  using psAdvectionCalback<NumericType, D>::domain;
+  csTracing<NumericType, D> tracer;
 
 public:
   DamageModel(const NumericType energy, const NumericType meanFreePath,
@@ -198,9 +198,12 @@ public:
   }
 
   virtual void applyPreAdvect(const NumericType processTime) {
+    assert(domain->useCellSet());
+
     tracer.setCellSet(domain->getCellSet());
     tracer.apply();
   }
+
   virtual void applyPostAdvect(const NumericType advectionTime) {}
 };
 
@@ -217,7 +220,7 @@ public:
         ionEnergy, meanFreePath, maskMaterial);
 
     processModel->setProcessName("PlasmaDamage");
-    processModel->setVolumeModel(volumeModel);
+    processModel->setAdvectionCallback(volumeModel);
   }
 
   psSmartPointer<psProcessModel<NumericType, D>> getProcessModel() {

--- a/include/Models/PlasmaDamage.hpp
+++ b/include/Models/PlasmaDamage.hpp
@@ -198,7 +198,7 @@ public:
   }
 
   virtual void applyPreAdvect(const NumericType processTime) {
-    assert(domain->useCellSet());
+    assert(domain->getUseCellSet());
 
     tracer.setCellSet(domain->getCellSet());
     tracer.apply();

--- a/include/psAdvectionCallback.hpp
+++ b/include/psAdvectionCallback.hpp
@@ -1,14 +1,12 @@
-#ifndef PS_VOLUME_MODEL
-#define PS_VOLUME_MODEL
+#ifndef PS_ADVECTION_CALLBACK
+#define PS_ADVECTION_CALLBACK
 
-#include <csTracing.hpp>
 #include <psDomain.hpp>
 #include <psSmartPointer.hpp>
 
-template <typename NumericType, int D> class psVolumeModel {
+template <typename NumericType, int D> class psAdvectionCalback {
 protected:
   psSmartPointer<psDomain<NumericType, D>> domain = nullptr;
-  csTracing<NumericType, D> tracer;
 
 public:
   void setDomain(psSmartPointer<psDomain<NumericType, D>> passedDomain) {
@@ -16,6 +14,7 @@ public:
   }
 
   virtual void applyPreAdvect(const NumericType processTime) {}
+
   virtual void applyPostAdvect(const NumericType advectionTime) {}
 };
 

--- a/include/psProcess.hpp
+++ b/include/psProcess.hpp
@@ -7,13 +7,13 @@
 #include <lsMessage.hpp>
 #include <lsToDiskMesh.hpp>
 
+#include <psAdvectionCallback.hpp>
 #include <psDomain.hpp>
 #include <psProcessModel.hpp>
 #include <psSmartPointer.hpp>
 #include <psSurfaceModel.hpp>
 #include <psTranslationField.hpp>
 #include <psVelocityField.hpp>
-#include <psVolumeModel.hpp>
 
 #include <rayBoundCondition.hpp>
 #include <rayParticle.hpp>
@@ -77,13 +77,13 @@ public:
     }
 
     if (processDuration == 0.) {
-      // apply only volume model
-      if (model->getVolumeModel()) {
-        model->getVolumeModel()->setDomain(domain);
-        model->getVolumeModel()->applyPreAdvect(0);
+      // apply only advection callback
+      if (model->getAdvectionCallback()) {
+        model->getAdvectionCallback()->setDomain(domain);
+        model->getAdvectionCallback()->applyPreAdvect(0);
       } else {
         lsMessage::getInstance()
-            .addWarning("No volume model passed to psProcess.")
+            .addWarning("No advection callback passed to psProcess.")
             .print();
       }
       return;
@@ -138,11 +138,10 @@ public:
       rayTrace.setCalculateFlux(false);
     }
 
-    // Determine whether volume model is used
-    const bool useVolumeModel = model->getVolumeModel() != nullptr;
-    if (useVolumeModel) {
-      assert(domain->getUseCellSet());
-      model->getVolumeModel()->setDomain(domain);
+    // Determine whether advection callback is used
+    const bool useAdvectionCallback = model->getAdvectionCallback() != nullptr;
+    if (useAdvectionCallback) {
+      model->getAdvectionCallback()->setDomain(domain);
     }
 
     // Determine whether there are process parameters used in ray tracing
@@ -153,8 +152,8 @@ public:
 #ifdef VIENNAPS_VERBOSE
     if (useProcessParams)
       std::cout << "Using process parameters." << std::endl;
-    if (useVolumeModel)
-      std::cout << "Using volume model." << std::endl;
+    if (useAdvectionCallback)
+      std::cout << "Using advection callback." << std::endl;
 #endif
 
     bool useCoverages = false;
@@ -332,10 +331,10 @@ public:
         printDiskMesh(diskMesh,
                       name + "_" + std::to_string(counter++) + ".vtp");
 #endif
-      // apply volume model
-      if (useVolumeModel) {
-        model->getVolumeModel()->applyPreAdvect(processDuration -
-                                                remainingTime);
+      // apply advection callback
+      if (useAdvectionCallback) {
+        model->getAdvectionCallback()->applyPreAdvect(processDuration -
+                                                      remainingTime);
       }
 
       // move coverages to LS, so they get are moved with the advection step
@@ -350,10 +349,10 @@ public:
         updateCoveragesFromAdvectedSurface(
             translator, model->getSurfaceModel()->getCoverages());
 
-      // apply volume model
-      if (useVolumeModel) {
+      // apply advection callback
+      if (useAdvectionCallback) {
         domain->getCellSet()->updateSurface();
-        model->getVolumeModel()->applyPostAdvect(
+        model->getAdvectionCallback()->applyPostAdvect(
             advectionKernel.getAdvectedTime());
       }
 

--- a/include/psProcess.hpp
+++ b/include/psProcess.hpp
@@ -351,7 +351,8 @@ public:
 
       // apply advection callback
       if (useAdvectionCallback) {
-        domain->getCellSet()->updateSurface();
+        if (domain->getUseCellSet())
+          domain->getCellSet()->updateSurface();
         model->getAdvectionCallback()->applyPostAdvect(
             advectionKernel.getAdvectedTime());
       }

--- a/include/psProcessModel.hpp
+++ b/include/psProcessModel.hpp
@@ -1,11 +1,11 @@
 #ifndef PS_PROCESS_MODEL
 #define PS_PROCESS_MODEL
 
+#include <psAdvectionCallback.hpp>
 #include <psGeometricModel.hpp>
 #include <psSmartPointer.hpp>
 #include <psSurfaceModel.hpp>
 #include <psVelocityField.hpp>
-#include <psVolumeModel.hpp>
 
 #include <rayParticle.hpp>
 
@@ -16,7 +16,8 @@ private:
 
   psSmartPointer<ParticleTypeList> particles = nullptr;
   psSmartPointer<psSurfaceModel<NumericType>> surfaceModel = nullptr;
-  psSmartPointer<psVolumeModel<NumericType, D>> volumeModel = nullptr;
+  psSmartPointer<psAdvectionCalback<NumericType, D>> advectionCallback =
+      nullptr;
   psSmartPointer<psGeometricModel<NumericType, D>> geometricModel = nullptr;
   psSmartPointer<psVelocityField<NumericType>> velocityField = nullptr;
   std::string processName = "default";
@@ -28,8 +29,9 @@ public:
   virtual psSmartPointer<psSurfaceModel<NumericType>> getSurfaceModel() {
     return surfaceModel;
   }
-  virtual psSmartPointer<psVolumeModel<NumericType, D>> getVolumeModel() {
-    return volumeModel;
+  virtual psSmartPointer<psAdvectionCalback<NumericType, D>>
+  getAdvectionCallback() {
+    return advectionCallback;
   }
   virtual psSmartPointer<psGeometricModel<NumericType, D>> getGeometricModel() {
     return geometricModel;
@@ -56,10 +58,12 @@ public:
         passedSurfaceModel);
   }
 
-  template <typename VolumeModelType>
-  void setVolumeModel(psSmartPointer<VolumeModelType> passedVolumeModel) {
-    volumeModel = std::dynamic_pointer_cast<psVolumeModel<NumericType, D>>(
-        passedVolumeModel);
+  template <typename AdvectionCallbackType>
+  void setAdvectionCallback(
+      psSmartPointer<AdvectionCallbackType> passedAdvectionCallback) {
+    advectionCallback =
+        std::dynamic_pointer_cast<psAdvectionCalback<NumericType, D>>(
+            passedAdvectionCallback);
   }
 
   template <typename GeometricModelType>


### PR DESCRIPTION
* Moved cellset functionality out of volume model to allow for using volume model as an advection callback. This might be useful for hooking into the advection process for measurement or data extraction purposes.

* psDataSource now also contain the interface for writing data to the underlying data source (e.g. CSV file) completing the feedback loop required for data augmentation.