### PR TITLE
Python example syntax

### DIFF
--- a/examples/GDSReader/GDSReader.py
+++ b/examples/GDSReader/GDSReader.py
@@ -9,9 +9,9 @@ except ModuleNotFoundError:
 
 gridDelta = 0.01
 boundaryConds = [
-    vls.lsBoundaryConditionEnum.REFLECTIVE_BOUNDARY,
-    vls.lsBoundaryConditionEnum.REFLECTIVE_BOUNDARY,
-    vls.lsBoundaryConditionEnum.INFINITE_BOUNDARY,
+    vls.BoundaryConditionEnum.REFLECTIVE_BOUNDARY,
+    vls.BoundaryConditionEnum.REFLECTIVE_BOUNDARY,
+    vls.BoundaryConditionEnum.INFINITE_BOUNDARY,
 ]
 
 mask = vps.GDSGeometry(gridDelta)
@@ -24,8 +24,8 @@ geometry = vps.Domain()
 # substrate plane
 origin = [0.0, 0.0, 0.0]
 normal = [0.0, 0.0, 1.0]
-plane = vls.lsDomain(bounds, boundaryConds, gridDelta)
-vls.lsMakeGeometry(plane, vls.lsPlane(origin, normal)).apply()
+plane = vls.Domain(bounds, boundaryConds, gridDelta)
+vls.MakeGeometry(plane, vls.Plane(origin, normal)).apply()
 
 geometry.insertNextLevelSet(plane)
 

--- a/examples/cantileverWetEtching/cantileverWetEtching.py
+++ b/examples/cantileverWetEtching/cantileverWetEtching.py
@@ -22,9 +22,9 @@ gridDelta = 5.0  # um
 
 # read GDS mask file
 boundaryConditions = [
-    vls.lsBoundaryConditionEnum.REFLECTIVE_BOUNDARY,
-    vls.lsBoundaryConditionEnum.REFLECTIVE_BOUNDARY,
-    vls.lsBoundaryConditionEnum.INFINITE_BOUNDARY,
+    vls.BoundaryConditionEnum.REFLECTIVE_BOUNDARY,
+    vls.BoundaryConditionEnum.REFLECTIVE_BOUNDARY,
+    vls.BoundaryConditionEnum.INFINITE_BOUNDARY,
 ]
 
 gds_mask = vps.GDSGeometry(gridDelta)
@@ -37,8 +37,8 @@ mask = gds_mask.layerToLevelSet(1, 0.0, 4 * gridDelta, True)
 
 # create plane geometry as substrate
 bounds = gds_mask.getBounds()
-plane = vls.lsDomain(bounds, boundaryConditions, gridDelta)
-vls.lsMakeGeometry(plane, vls.lsPlane([0.0, 0.0, 0.0], [0.0, 0.0, 1.0])).apply()
+plane = vls.Domain(bounds, boundaryConditions, gridDelta)
+vls.MakeGeometry(plane, vls.Plane([0.0, 0.0, 0.0], [0.0, 0.0, 1.0])).apply()
 
 # set up domain
 geometry = vps.Domain()
@@ -62,7 +62,7 @@ process.setDomain(geometry)
 process.setProcessModel(model)
 process.setProcessDuration(5.0 * 60.0)  # 5 minutes of etching
 process.setIntegrationScheme(
-    vls.lsIntegrationSchemeEnum.STENCIL_LOCAL_LAX_FRIEDRICHS_1ST_ORDER
+    vls.IntegrationSchemeEnum.STENCIL_LOCAL_LAX_FRIEDRICHS_1ST_ORDER
 )
 
 for n in range(minutes):

--- a/examples/selectiveEpitaxy/selectiveEpitaxy.py
+++ b/examples/selectiveEpitaxy/selectiveEpitaxy.py
@@ -32,12 +32,12 @@ vps.MakePlane(
     material=vps.Material.Mask,
 ).apply()
 
-fin = vls.lsDomain(geometry.getLevelSets()[-1])
+fin = vls.Domain(geometry.getLevelSets()[-1])
 
 if args.dim == 3:
-    vls.lsMakeGeometry(
+    vls.MakeGeometry(
         fin,
-        vls.lsBox(
+        vls.Box(
             [
                 -params["finWidth"] / 2.0,
                 -params["finLength"] / 2.0,
@@ -47,9 +47,9 @@ if args.dim == 3:
         ),
     ).apply()
 else:
-    vls.lsMakeGeometry(
+    vls.MakeGeometry(
         fin,
-        vls.lsBox(
+        vls.Box(
             [
                 -params["finWidth"] / 2.0,
                 -params["gridDelta"],
@@ -75,7 +75,7 @@ process.setDomain(geometry)
 process.setProcessModel(model)
 process.setProcessDuration(params["processTime"])
 process.setIntegrationScheme(
-    vls.lsIntegrationSchemeEnum.STENCIL_LOCAL_LAX_FRIEDRICHS_1ST_ORDER
+    vls.IntegrationSchemeEnum.STENCIL_LOCAL_LAX_FRIEDRICHS_1ST_ORDER
 )
 
 geometry.saveVolumeMesh("initial")


### PR DESCRIPTION
Many examples, run out of the box*, give errors of type:

```
Traceback (most recent call last):
  File "/home/simbil/Github/ViennaPS/examples/GDSReader/GDSReader.py", line 27, in <module>
    plane = vls.lsDomain(bounds, boundaryConds, gridDelta)
            ^^^^^^^^^^^^
AttributeError: module 'viennals3d' has no attribute 'lsDomain'. Did you mean: 'Domain'?
```

Implementing the suggested change, as is done everywhere relevant in this PR, makes the scripts run.

*unless I set things up wrong! I followed the README of ViennaLS and ViennaPS