### PR TITLE
Python wrapper fixes

### DIFF
--- a/python/pyWrap.cpp
+++ b/python/pyWrap.cpp
@@ -680,6 +680,28 @@ PYBIND11_MODULE(VIENNAPS_MODULE_NAME, module) {
       .def("getParameters", &SF6O2Etching<T, D>::getParameters,
            pybind11::return_value_policy::reference);
 
+  // SF6 Etching
+  pybind11::class_<SF6Etching<T, D>, SmartPointer<SF6Etching<T, D>>>(
+      module, "SF6Etching", processModel)
+      .def(pybind11::init<>())
+      .def(
+          pybind11::init(&SmartPointer<SF6Etching<T, D>>::New<
+                         const double /*ionFlux*/, const double /*etchantFlux*/,
+                         const T /*meanIonEnergy*/, const T /*sigmaIonEnergy*/,
+                         const T /*ionExponent*/, const T /*etchStopDepth*/>),
+          pybind11::arg("ionFlux"), pybind11::arg("etchantFlux"),
+          pybind11::arg("meanIonEnergy") = 100.,
+          pybind11::arg("sigmaIonEnergy") = 10.,
+          pybind11::arg("ionExponent") = 100.,
+          pybind11::arg("etchStopDepth") = std::numeric_limits<T>::lowest())
+      .def(
+          pybind11::init(
+              &SmartPointer<SF6Etching<T, D>>::New<const SF6O2Parameters<T> &>),
+          pybind11::arg("parameters"))
+      .def("setParameters", &SF6Etching<T, D>::setParameters)
+      .def("getParameters", &SF6Etching<T, D>::getParameters,
+           pybind11::return_value_policy::reference);
+
   // Fluorocarbon Parameters
   pybind11::class_<FluorocarbonParameters<T>::MaskType>(
       module, "FluorocarbonParametersMask")
@@ -792,7 +814,7 @@ PYBIND11_MODULE(VIENNAPS_MODULE_NAME, module) {
              return SmartPointer<IsotropicProcess<T, D>>::New(rate, mask);
            }),
            pybind11::arg("rate") = 1.,
-           pybind11::arg("maskMaterial") = Material::Mask)
+           pybind11::arg("maskMaterial") = Material::None)
       .def(pybind11::init([](const T rate, const std::vector<Material> mask) {
              return SmartPointer<IsotropicProcess<T, D>>::New(rate, mask);
            }),


### PR DESCRIPTION
- Change the default mask material is IsotropicProcess to `None`
- Add wrapper for the SF6Etching model