### PR TITLE
Fix/alp time loop termination

### DIFF
--- a/include/viennaps/models/psSingleParticleALD.hpp
+++ b/include/viennaps/models/psSingleParticleALD.hpp
@@ -12,7 +12,7 @@ template <typename NumericType>
 class SingleParticleALDSurfaceModel : public SurfaceModel<NumericType> {
   using SurfaceModel<NumericType>::coverages;
 
-  const NumericType dt_;
+  NumericType dt_;
   const NumericType gpc_;
   const NumericType s0_;
 
@@ -36,6 +36,8 @@ public:
     std::vector<NumericType> cov(numPoints, 0.);
     coverages->insertNextScalarData(cov, "Coverage");
   }
+
+  void setTimeStep(NumericType dt) override { dt_ = dt; }
 
   SmartPointer<std::vector<NumericType>>
   calculateVelocities(SmartPointer<viennals::PointData<NumericType>> rates,

--- a/include/viennaps/process/psALPStrategy.hpp
+++ b/include/viennaps/process/psALPStrategy.hpp
@@ -162,7 +162,9 @@ private:
 
       double time = 0.;
       unsigned pulseIteration = 0;
-      while (std::fabs(time - pulseTime) > 1e-6) {
+      const double coverageTimeStep =
+          context.atomicLayerParams.coverageTimeStep;
+      while (time < pulseTime - coverageTimeStep * 1e-4) {
 #ifdef VIENNATOOLS_PYTHON_BUILD
         // Check for user interruption
         if (PyErr_CheckSignals() != 0)
@@ -178,7 +180,7 @@ private:
 
         outputIntermediateResults(context, fluxes, pulseIteration);
 
-        time += context.atomicLayerParams.coverageTimeStep;
+        time += coverageTimeStep;
         pulseIteration++;
 
         if (Logger::hasInfo()) {

--- a/include/viennaps/process/psALPStrategy.hpp
+++ b/include/viennaps/process/psALPStrategy.hpp
@@ -171,6 +171,10 @@ private:
           return ProcessResult::USER_INTERRUPTED;
 #endif
 
+        // Clamp last step to land exactly on pulseTime
+        double dt = std::min(coverageTimeStep, pulseTime - time);
+        context.model->getSurfaceModel()->setTimeStep(dt);
+
         // Calculate fluxes
         auto fluxes = SmartPointer<viennals::PointData<NumericType>>::New();
         PROCESS_CHECK(fluxEngine_->calculateFluxes(context, fluxes));
@@ -180,7 +184,7 @@ private:
 
         outputIntermediateResults(context, fluxes, pulseIteration);
 
-        time += coverageTimeStep;
+        time += dt;
         pulseIteration++;
 
         if (Logger::hasInfo()) {

--- a/include/viennaps/process/psSurfaceModel.hpp
+++ b/include/viennaps/process/psSurfaceModel.hpp
@@ -32,6 +32,8 @@ public:
     // if no surface data get initialized here, they won't be used at all
   }
 
+  virtual void setTimeStep(NumericType dt) {}
+
   virtual SmartPointer<std::vector<NumericType>>
   calculateVelocities(SmartPointer<viennals::PointData<NumericType>> fluxes,
                       const std::vector<Vec3D<NumericType>> &coordinates,


### PR DESCRIPTION
## Summary
  The ALP pulse-time loop had two bugs:                                                       
   
  1. **Broken termination condition.** `while (std::fabs(time - pulseTime) > 1e-6)` only exits
   when `time` lands within 1e-6 of `pulseTime`. For any `pulseTime / coverageTimeStep` that
  is not an exact integer, `time` overshoots and the fabs keeps growing — the loop never      
  exits. Only the "neatly divisible" case worked.      
  2. **Last-step overshoot.** The final iteration runs fluxes and
  coverage updates with the full `coverageTimeStep`, so the physics integrates over more time 
  than actually remains in the pulse.
                                                                                              
  ## Changes                                                
  - **Commit 1** — replace the fabs guard with a monotonic `time < pulseTime -
  coverageTimeStep * 1e-4` check so the loop terminates for arbitrary `pulseTime /            
  coverageTimeStep` ratios and is invariant of the time scale.
  - **Commit 2** — clamp `dt = min(coverageTimeStep, pulseTime - time)` and push it to the    
  surface model via a new `setTimeStep` hook on `SurfaceModel`, so the final iteration        
  integrates over the actual remaining time. `SingleParticleALDSurfaceModel` overrides the
  hook to update its (now non-const) `dt_`; base-class default is a no-op so other models are 
  unaffected.