### PR TITLE
fix: include psIonModelUtil.hpp in psTEOSPECVD.hpp

### DIFF
--- a/include/viennaps/models/psTEOSPECVD.hpp
+++ b/include/viennaps/models/psTEOSPECVD.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../process/psProcessModel.hpp"
+#include "psIonModelUtil.hpp"
 
 #include <rayParticle.hpp>
 #include <rayReflection.hpp>


### PR DESCRIPTION
psTEOSPECVD.hpp uses getCosTheta() which is defined in psIonModelUtil.hpp, but never includes that header. The build only succeeds today when a sibling translation unit transitively brings psIonModelUtil.hpp into scope; isolated compilation (e.g. from a ParaView plugin that only includes deposition-model headers) fails with 'getCosTheta was not declared in this scope'.